### PR TITLE
ci(security): add GitHub Actions workflow for static security scans

### DIFF
--- a/.github/workflows/security-scan.yaml
+++ b/.github/workflows/security-scan.yaml
@@ -1,0 +1,59 @@
+name: ci-cd-security-validation
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  security-scans:
+    name: Run Static Security Scans
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Install Semgrep
+        run: |
+          pip install semgrep
+
+      - name: Semgrep Scan (Python)
+        run: |
+          semgrep --config p/ci --error
+
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.6.6
+
+      - name: Terraform Format
+        run: |
+         terraform fmt -check -recursive
+
+      - name: Terraform Init
+        run: |  
+          terraform init
+      - name: Terraform Validate
+        run: |
+          terraform validate
+
+      - name: Install Checkov
+        run: |
+          pip install checkov
+
+      - name: Checkov Scan (Terraform)
+        run: |
+          checkov -d .
+
+      - name: Scan K8s Manifests with Checkov
+        run: |
+          checkov -d ./k8s


### PR DESCRIPTION
- add .github/workflows/security-scan.yaml (job: ci-cd-security-validation)
- run semgrep for Python, install/check with  to fail on findings
- run terraform fmt/check/init/validate using HashiCorp's setup-terraform
- run Checkov for Terraform and scan Kubernetes manifests
- set up Python 3.11 and Terraform 1.6.6; run on push/PR to main
- provides basic infra linting and security validation as part of CI